### PR TITLE
Fixes IASsure loading bug

### DIFF
--- a/Plugins/IASsure/config.json
+++ b/Plugins/IASsure/config.json
@@ -1,10 +1,10 @@
 {
-    "mach.prefix":{
+    "mach":{
         "digits":2,
-        "thresholdFL":245
+        "thresholdFL":245,
+        "prefix":"@M"
     },
-    "ias.prefix":{
-        "ias":"@N",
-        "mach":"@M"
+    "ias":{
+        "prefix":"@N"
     }
 }

--- a/Plugins/IASsure/config.json
+++ b/Plugins/IASsure/config.json
@@ -1,9 +1,9 @@
 {
-    "mach":{
+    "mach.prefix":{
         "digits":2,
         "thresholdFL":245
     },
-    "prefix":{
+    "ias.prefix":{
         "ias":"@N",
         "mach":"@M"
     }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?


- [x] Bug Fix
- [ ] Feature / Enhancement
- [ ] Plugins
- [ ] Documentation
- [ ] Other


## Issue Number and Link
N/A


## Describe Your Changes
Updated the config file, by restructuring it, to remove the error generated on ES load. This is due to the object "prefix" being [deprecated ](https://github.com/MorpheusXAUT/IASsure?tab=readme-ov-file#prefix-object-deprecated) , and replaced with the prefix being an element inside the [ias](https://github.com/MorpheusXAUT/IASsure?tab=readme-ov-file#ias-object) and [mach](https://github.com/MorpheusXAUT/IASsure?tab=readme-ov-file#mach-object) objects, rather than being in an prefix object of its own.

Fixes this bug:
![image](https://github.com/user-attachments/assets/7155e362-4893-4e80-9e8e-e1b6520effef)



# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have tested my changes in my local setup
- [x] My changes generate no new warnings
