### PR TITLE
Update "FALA SMC.asr" to set default Runway 07/25 visibility

### DIFF
--- a/ASR/SMC/FALA SMC.asr
+++ b/ASR/SMC/FALA SMC.asr
@@ -1,8 +1,9 @@
 DisplayTypeName:Ground Radar display
 DisplayTypeNeedRadarContent:0
 DisplayTypeGeoReferenced:1
-SECTORFILE:
-SECTORTITLE:
+SECTORFILE:Z:\home\cake\code\vatssa\sct\FASA\FASA-Package_20251201205633-251201-0008.sct
+SECTORTITLE:FASA-Package_20251201205633-251201-0008.sct
+Regions:FALA Ground Layout:polygon
 SHOWC:1
 SHOWSB:1
 BELOW:0
@@ -16,7 +17,7 @@ DISABLEPANNING:1
 DISABLEZOOMING:1
 DisplayRotation:43.00000
 TAGFAMILY:Matias (built in)
-WINDOWAREA:-25.951983:27.902994:-25.925391:27.951226
+WINDOWAREA:-25.951983:27.899808:-25.925391:27.954412
 PLUGIN:Ground Radar plugin:AirportElevation:4521
 PLUGIN:Ground Radar plugin:AirportRadius:3
 PLUGIN:Ground Radar plugin:GroundMode:FALA


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bug Fix
- [ ] Feature / Enhancement
- [ ] Plugins
- [ ] Documentation
- [ ] Other

## Issue Number and Link

- Issue #227 

## Describe Your Changes

- Enables the FALA Runway 07/25 region to be visible by default when launching "FALA SMC.asr"
- NOTE: This change should only be implemented if the corresponding change was made to the FASA sector file (.sct) (See [Issue #227](https://github.com/VATSIM-SSA/sectorfile-fasa/issues/227#issuecomment-3711983190))

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have tested my changes in my local setup
- [X] My changes generate no new warnings
